### PR TITLE
unix-auth: add username checker and key challenge verifier

### DIFF
--- a/modules/unix-auth/.env.sample
+++ b/modules/unix-auth/.env.sample
@@ -1,2 +1,5 @@
 # unix-auth module sample configuration
-
+UNIX_AUTH_ENABLED=1
+UNIX_PROVISION_ALLOWED=1
+UNIX_DEFAULT_GROUP=snort
+UNIX_HOME_BASE=/srv/snort/users

--- a/modules/unix-auth/README.md
+++ b/modules/unix-auth/README.md
@@ -1,4 +1,45 @@
 # unix-auth module
 
-Stub module for Snort.
+## Purpose
+Provide SSH key–based authentication for limited Unix file access tied to Snort uploads.
 
+## Threat model
+Assumes untrusted remote users. Only public key challenges are accepted; no passwords.
+
+## Configuration
+| Variable | Description |
+| --- | --- |
+| `UNIX_AUTH_ENABLED` | Set to `1` to enable the module. |
+| `UNIX_PROVISION_ALLOWED` | Allow self-service Unix user provisioning when `1`. |
+| `UNIX_DEFAULT_GROUP` | POSIX group assigned to new users. |
+| `UNIX_HOME_BASE` | Directory under which user homes are created. |
+
+Usernames must be lowercase letters only (`[a-z]`) and 1–32 characters long.
+
+### Public key challenge
+
+The script `scripts/verify_challenge.sh` validates a signature against a challenge
+using a supplied public key. It relies on `ssh-keygen -Y verify` with the
+namespace set to `snort`.
+
+### User provisioning
+
+The script `scripts/provision_user.sh` creates a Unix account for a validated
+username when `UNIX_PROVISION_ALLOWED=1`. It assigns the new user to
+`UNIX_DEFAULT_GROUP`, creates a home under `UNIX_HOME_BASE`, and installs the
+provided public key as `authorized_keys`.
+
+## Failure modes
+* Username contains invalid characters or exceeds 32 characters.
+* Username already exists on the system.
+* Signature does not verify against the provided public key.
+* Group specified in `UNIX_DEFAULT_GROUP` is missing.
+* Provisioning attempted when `UNIX_PROVISION_ALLOWED` is not `1`.
+
+## Logs
+Scripts log to stdout/stderr; direct systemd units capture output in journal.
+
+## Test recipe
+```
+bats tests
+```

--- a/modules/unix-auth/scripts/check_username.sh
+++ b/modules/unix-auth/scripts/check_username.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <username>" >&2
+  exit 1
+}
+
+main() {
+  [ "${1:-}" ] || usage
+  local name="$1"
+  if [[ ! "$name" =~ ^[a-z]{1,32}$ ]]; then
+    echo "invalid username" >&2
+    exit 1
+  fi
+  if id -u "$name" > /dev/null 2>&1; then
+    echo "user exists" >&2
+    exit 1
+  fi
+  echo "ok"
+}
+
+main "$@"

--- a/modules/unix-auth/scripts/provision_user.sh
+++ b/modules/unix-auth/scripts/provision_user.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <username> <pubkey_file>" >&2
+  exit 1
+fi
+
+username="$1"
+pubkey="$2"
+
+: "${UNIX_PROVISION_ALLOWED?need UNIX_PROVISION_ALLOWED}"
+: "${UNIX_DEFAULT_GROUP?need UNIX_DEFAULT_GROUP}"
+: "${UNIX_HOME_BASE?need UNIX_HOME_BASE}"
+
+if [[ "$UNIX_PROVISION_ALLOWED" != "1" ]]; then
+  echo "provisioning disabled" >&2
+  exit 1
+fi
+
+if [[ ! -f "$pubkey" ]]; then
+  echo "public key file not found" >&2
+  exit 1
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+"$script_dir/check_username.sh" "$username"
+
+if ! getent group "$UNIX_DEFAULT_GROUP" > /dev/null; then
+  echo "group $UNIX_DEFAULT_GROUP not found" >&2
+  exit 1
+fi
+
+home_dir="$UNIX_HOME_BASE/$username"
+mkdir -p "$UNIX_HOME_BASE"
+useradd -d "$home_dir" -g "$UNIX_DEFAULT_GROUP" -m -s /bin/bash "$username"
+
+install -d -m 700 -o "$username" -g "$UNIX_DEFAULT_GROUP" "$home_dir/.ssh"
+install -m 600 -o "$username" -g "$UNIX_DEFAULT_GROUP" "$pubkey" "$home_dir/.ssh/authorized_keys"
+
+echo "provisioned $username"

--- a/modules/unix-auth/scripts/verify_challenge.sh
+++ b/modules/unix-auth/scripts/verify_challenge.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <pubkey_file> <challenge_file> <signature_file>" >&2
+  exit 1
+}
+
+main() {
+  [ "$#" -eq 3 ] || usage
+  local pubkey="$1" challenge="$2" sig="$3"
+
+  for f in "$pubkey" "$challenge" "$sig"; do
+    if [[ ! -f "$f" ]]; then
+      echo "file not found: $f" >&2
+      exit 1
+    fi
+  done
+
+  local allowed principal keytype keydata
+  principal=$(awk '{print $3}' "$pubkey")
+  keytype=$(awk '{print $1}' "$pubkey")
+  keydata=$(awk '{print $2}' "$pubkey")
+
+  allowed=$(mktemp)
+  trap 'rm -f "${allowed:-}"' EXIT
+  printf '%s %s %s\n' "$principal" "$keytype" "$keydata" > "$allowed"
+
+  if ssh-keygen -Y verify -f "$allowed" -I "$principal" -n snort -s "$sig" < "$challenge" > /dev/null 2>&1; then
+    echo "ok"
+  else
+    echo "invalid signature" >&2
+    exit 1
+  fi
+}
+
+main "$@"

--- a/modules/unix-auth/tests/check_username.bats
+++ b/modules/unix-auth/tests/check_username.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+  cd "$(dirname "$BATS_TEST_FILENAME")/.."
+}
+
+@test "fails on invalid characters" {
+  run scripts/check_username.sh 'bad!'
+  [ "$status" -ne 0 ]
+}
+
+@test "fails on digits or hyphens" {
+  run scripts/check_username.sh 'user-1'
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when longer than 32 chars" {
+  run scripts/check_username.sh 'averylongusernamethatisoverthirtytwochars'
+  [ "$status" -ne 0 ]
+}
+
+@test "fails on existing user" {
+  run scripts/check_username.sh 'root'
+  [ "$status" -ne 0 ]
+}
+
+@test "succeeds on unused name" {
+  run scripts/check_username.sh 'snorttestuser'
+  [ "$status" -eq 0 ]
+}

--- a/modules/unix-auth/tests/provision_user.bats
+++ b/modules/unix-auth/tests/provision_user.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+setup() {
+  SCRIPTS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+}
+
+@test "provisioning disabled" {
+  export UNIX_PROVISION_ALLOWED=0
+  export UNIX_DEFAULT_GROUP=nogroup
+  export UNIX_HOME_BASE="$BATS_TEST_TMPDIR/home"
+  run "$SCRIPTS_DIR/provision_user.sh" foo key.pub
+  [ "$status" -eq 1 ]
+}
+
+@test "creates user and installs key" {
+  username="snorttestuser"
+  group="snortgrp"
+  keyfile="$BATS_TEST_TMPDIR/id_ed25519.pub"
+  echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKeyForTests test" > "$keyfile"
+  getent passwd "$username" > /dev/null && userdel -r "$username"
+  getent group "$group" > /dev/null && groupdel "$group"
+  groupadd "$group"
+  export UNIX_PROVISION_ALLOWED=1
+  export UNIX_DEFAULT_GROUP="$group"
+  export UNIX_HOME_BASE="$BATS_TEST_TMPDIR/home"
+  run "$SCRIPTS_DIR/provision_user.sh" "$username" "$keyfile"
+  [ "$status" -eq 0 ]
+  id "$username" > /dev/null
+  [ -f "$UNIX_HOME_BASE/$username/.ssh/authorized_keys" ]
+  grep -q "MockKeyForTests" "$UNIX_HOME_BASE/$username/.ssh/authorized_keys"
+  userdel -r "$username"
+  groupdel "$group"
+}

--- a/modules/unix-auth/tests/verify_challenge.bats
+++ b/modules/unix-auth/tests/verify_challenge.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+setup() {
+  cd "$(dirname "$BATS_TEST_FILENAME")/.."
+  tmpdir=$(mktemp -d)
+}
+
+teardown() {
+  rm -rf "$tmpdir"
+}
+
+@test "verifies valid signature" {
+  ssh-keygen -t ed25519 -N "" -f "$tmpdir/key" > /dev/null 2>&1
+  echo "hello" > "$tmpdir/challenge"
+  ssh-keygen -Y sign -f "$tmpdir/key" -n snort "$tmpdir/challenge" > /dev/null 2>&1
+  run scripts/verify_challenge.sh "$tmpdir/key.pub" "$tmpdir/challenge" "$tmpdir/challenge.sig"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails when file missing" {
+  ssh-keygen -t ed25519 -N "" -f "$tmpdir/key" > /dev/null 2>&1
+  echo "hello" > "$tmpdir/challenge"
+  ssh-keygen -Y sign -f "$tmpdir/key" -n snort "$tmpdir/challenge" > /dev/null 2>&1
+  rm "$tmpdir/challenge.sig"
+  run scripts/verify_challenge.sh "$tmpdir/key.pub" "$tmpdir/challenge" "$tmpdir/challenge.sig"
+  [ "$status" -ne 0 ]
+}
+
+@test "fails on bad signature" {
+  ssh-keygen -t ed25519 -N "" -f "$tmpdir/key1" > /dev/null 2>&1
+  ssh-keygen -t ed25519 -N "" -f "$tmpdir/key2" > /dev/null 2>&1
+  echo "hello" > "$tmpdir/challenge"
+  ssh-keygen -Y sign -f "$tmpdir/key1" -n snort "$tmpdir/challenge" > /dev/null 2>&1
+  run scripts/verify_challenge.sh "$tmpdir/key2.pub" "$tmpdir/challenge" "$tmpdir/challenge.sig"
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when challenge modified" {
+  ssh-keygen -t ed25519 -N "" -f "$tmpdir/key" > /dev/null 2>&1
+  echo "hello" > "$tmpdir/challenge"
+  ssh-keygen -Y sign -f "$tmpdir/key" -n snort "$tmpdir/challenge" > /dev/null 2>&1
+  echo "tamper" >> "$tmpdir/challenge"
+  run scripts/verify_challenge.sh "$tmpdir/key.pub" "$tmpdir/challenge" "$tmpdir/challenge.sig"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary
- document unix-auth module with purpose, config, and test instructions
- add script to validate prospective Unix usernames and provision users with SSH keys
- add script verifying SSH public key challenges
- ensure provisioning helper reports success on stdout
- cover username validation, challenge verification, and provisioning with Bats tests

## Testing
- `shellcheck modules/unix-auth/scripts/check_username.sh modules/unix-auth/scripts/verify_challenge.sh modules/unix-auth/scripts/provision_user.sh`
- `shfmt -i 2 -sr -w modules/unix-auth/scripts/check_username.sh modules/unix-auth/scripts/verify_challenge.sh modules/unix-auth/scripts/provision_user.sh modules/unix-auth/tests/check_username.bats modules/unix-auth/tests/verify_challenge.bats modules/unix-auth/tests/provision_user.bats`
- `bats modules/unix-auth/tests`


------
https://chatgpt.com/codex/tasks/task_e_68c074eea65083208447f90c52f5fa2f