### PR TITLE
fix: repair CI npm step and ops test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck shfmt bats redis-server ffmpeg
+          sudo apt-get install -y shellcheck shfmt bats redis-server ffmpeg websocketd
       - name: Install Node dependencies
         run: |
-          npm ci --prefix modules/realtime/node
+          npm install --prefix modules/realtime/node
+          npm install --prefix modules/ws-fallback/node
       - name: Run shellcheck
         run: shellcheck $(git ls-files '*.sh')
       - name: Run shfmt

--- a/core/tests/ops.bats
+++ b/core/tests/ops.bats
@@ -1,5 +1,9 @@
 #!/usr/bin/env bats
 
+setup() {
+  cd "$(dirname "$BATS_TEST_FILENAME")/.."
+}
+
 @test "ops files provide sample configs" {
   [ -f ops/nginx.conf ]
   grep -q 'server {' ops/nginx.conf


### PR DESCRIPTION
## Summary
- install websocketd and use `npm install` for realtime and ws-fallback modules
- fix core ops test by running from the correct directory

## Testing
- `shellcheck $(git ls-files '*.sh')`
- `shfmt -i 2 -sr -d $(git ls-files '*.sh' '*.bats')`
- `bats $(git ls-files '*.bats')`


------
https://chatgpt.com/codex/tasks/task_e_68c4b89b59f48320a1cf7835bfd89109