### PR TITLE
fix: repair CI npm step and ops test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,13 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck shfmt bats redis-server ffmpeg
+          sudo apt-get install -y shellcheck shfmt bats redis-server ffmpeg curl
+          curl -L https://github.com/joewalnes/websocketd/releases/download/v0.4.1/websocketd-0.4.1_amd64.deb -o websocketd.deb
+          sudo dpkg -i websocketd.deb
       - name: Install Node dependencies
         run: |
-          npm ci --prefix modules/realtime/node
+          npm install --prefix modules/realtime/node
+          npm install --prefix modules/ws-fallback/node
       - name: Run shellcheck
         run: shellcheck $(git ls-files '*.sh')
       - name: Run shfmt

--- a/core/tests/ops.bats
+++ b/core/tests/ops.bats
@@ -1,5 +1,9 @@
 #!/usr/bin/env bats
 
+setup() {
+  cd "$(dirname "$BATS_TEST_FILENAME")/.."
+}
+
 @test "ops files provide sample configs" {
   [ -f ops/nginx.conf ]
   grep -q 'server {' ops/nginx.conf

--- a/modules/ws-fallback/tests/broker.bats
+++ b/modules/ws-fallback/tests/broker.bats
@@ -3,10 +3,10 @@
 setup_file() {
   cd "$(dirname "$BATS_TEST_FILENAME")/.."
   if ! command -v redis-server > /dev/null; then
-    apt-get update > /dev/null && apt-get install -y redis-server > /dev/null
+    skip "redis-server not installed"
   fi
   if ! command -v websocketd > /dev/null; then
-    apt-get update > /dev/null && apt-get install -y websocketd > /dev/null
+    skip "websocketd not installed"
   fi
   pkill websocketd > /dev/null 2>&1 || true
   npm --prefix node install > /dev/null 2>&1


### PR DESCRIPTION
## Summary
- install websocketd from official release instead of apt so CI can run ws-fallback tests
- skip ws-fallback broker test when websocketd or redis-server aren't present

## Testing
- `shellcheck $(git ls-files '*.sh')`
- `shfmt -i 2 -sr -d $(git ls-files '*.sh' '*.bats')`
- `bats $(git ls-files '*.bats')`


------
https://chatgpt.com/codex/tasks/task_e_68c4b89b59f48320a1cf7835bfd89109