### PR TITLE
Add progressive interactivity for Snort post pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,65 @@ make -C core fetch render release
 See the [Quickstart](core/QUICKSTART.md) for a detailed walkthrough and the
 [module directory](modules/) for individual module documentation.
 
+## Interactivity
+
+Rendering includes lightweight hooks for live replies and reactions when the
+interactivity feature is enabled. Configure the behavior through the core
+`.env` file:
+
+* `INTERACT_ENABLE` – set to `0` to omit the browser module entirely.
+* `INTERACT_LIMIT` – maximum events fetched per subscription (default `80`).
+* `INTERACT_SHOW_REPLY` – reveal the reply button when a NIP-07 provider is
+  present.
+* `INTERACT_RELAYS` – JSON array of relay URLs or relative WebSocket paths.
+
+With the defaults enabled, post pages stream new replies and reaction counts
+from the configured relay and offer a NIP-07 reply dialog as a progressive
+enhancement. Set `INTERACT_ENABLE=0` to keep the site fully static and skip the
+module tag entirely for environments where WebSockets are unavailable.
+
+Each rendered post exposes predictable hooks so custom themes can restyle the
+interactive elements:
+
+```html
+<body
+  data-event-id="EVENT_ID"
+  data-addr="30023:PUBKEY:SLUG"
+  data-author-pubkey="PUBKEY"
+  data-relays='["wss://yourdomain/nostr"]'
+  data-limit="80"
+  data-show-reply="1"
+>
+  <main>…post body…</main>
+
+  <aside id="reactions" aria-label="Reactions">
+    <span data-reaction="+">0</span>
+    <span data-reaction="❤️">0</span>
+  </aside>
+
+  <section id="replies" aria-live="polite"></section>
+
+  <button id="load-more" hidden aria-controls="replies">Load more</button>
+  <button
+    id="reply-btn"
+    hidden
+    aria-haspopup="dialog"
+    aria-controls="reply-dialog"
+    aria-expanded="false"
+  >
+    Reply
+  </button>
+</body>
+```
+
+When WebSockets or relays fail, the client adds a `Live view unavailable.`
+banner near the top of the page but leaves the static content intact.
+
+Expose the relay through your edge proxy so browsers can connect to it. The
+sample [`core/ops/nginx.conf`](core/ops/nginx.conf) adds a `/nostr` location
+block that upgrades WebSocket connections and forwards them to the local relay
+service.
+
 ## Development
 
 Use the root `Makefile` to lint, test, or gather coverage across the project:

--- a/core/.env.example
+++ b/core/.env.example
@@ -10,3 +10,9 @@ RUNTIME_ROOT="${SNORT_ROOT}/run"
 # Enable modules (comma-separated)
 MODULES=nostr,realtime,comments,zaps,uploads,video-mirror,unix-auth,pwa
 
+# Interactivity defaults
+INTERACT_ENABLE=1
+INTERACT_LIMIT=80
+INTERACT_SHOW_REPLY=1
+INTERACT_RELAYS="[\"/nostr\"]"
+

--- a/core/Makefile
+++ b/core/Makefile
@@ -16,3 +16,4 @@ test:
 	shfmt -i 2 -sr -d scripts tests
 	shellcheck scripts/*.sh
 	bats tests
+	node --test tests/snort.test.mjs tests/snort.integration.test.mjs

--- a/core/OPERATIONS.md
+++ b/core/OPERATIONS.md
@@ -32,6 +32,24 @@ Logs live under `${LOG_ROOT}` and may be rotated with `logrotate`:
 
 Rendering occurs in `core/public`; `make release` atomically swaps `$SITE_ROOT/current` to the new build using `rsync` and a symlink.
 
+## WebSocket proxy
+
+Expose the relay that serves live replies and reactions behind your TLS proxy.
+The sample [`ops/nginx.conf`](ops/nginx.conf) includes a `/nostr` block:
+
+```
+  location /nostr {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 300s;
+    proxy_pass http://127.0.0.1:7778;
+  }
+```
+
+Adjust the upstream address to match your relay (e.g., Stonr) and ensure the
+relay is reachable from the web server.
+
 ## Failure modes
 
 * Insufficient disk space – renders or logs fail

--- a/core/QUICKSTART.md
+++ b/core/QUICKSTART.md
@@ -48,6 +48,10 @@ This rsyncs the build to `$SITE_ROOT/current` for serving.
 | `LOG_ROOT` | Log files |
 | `RUNTIME_ROOT` | PID files, sockets, temporary data |
 | `MODULES` | Comma-separated modules to enable |
+| `INTERACT_ENABLE` | `1` enables the client module for live replies |
+| `INTERACT_LIMIT` | Max replies/reactions fetched per subscription |
+| `INTERACT_SHOW_REPLY` | Reveal the Reply button when NIP-07 is present |
+| `INTERACT_RELAYS` | JSON array of relay WebSocket endpoints |
 
 ## Failure modes
 

--- a/core/ops/nginx.conf
+++ b/core/ops/nginx.conf
@@ -11,13 +11,22 @@ server {
   ssl_certificate_key /etc/nginx/ssl/$DOMAIN/$DOMAIN.key;
 
   root $SITE_ROOT/current/public;
-  add_header Content-Security-Policy "default-src 'self'";
+  set $csp "default-src 'self'; connect-src 'self' wss://$host; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'";
+  add_header Content-Security-Policy $csp;
 
   location /live/ {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_pass http://127.0.0.1:9001;
+  }
+
+  location /nostr {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 300s;
+    proxy_pass http://127.0.0.1:7778;
   }
 
   location /api/ { proxy_pass http://127.0.0.1:9002; }

--- a/core/package.json
+++ b/core/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/core/static/js/snort.js
+++ b/core/static/js/snort.js
@@ -1,0 +1,827 @@
+const FOCUSABLE_SELECTOR = 'textarea, button';
+const REPLY_DIALOG_ID = 'reply-dialog';
+
+function randomSubId() {
+  return Math.random().toString(36).slice(2);
+}
+
+export function normalizeRelayUrl(entry, win = typeof window !== 'undefined' ? window : undefined) {
+  if (typeof entry !== 'string') return null;
+  const trimmed = entry.trim();
+  if (!trimmed) return null;
+
+  const location = win?.location;
+  let baseHref = 'https://localhost/';
+  if (location?.href) {
+    baseHref = location.href;
+  } else if (location?.origin) {
+    baseHref = `${location.origin}/`;
+  } else if (location?.protocol && location?.host) {
+    baseHref = `${location.protocol}//${location.host}/`;
+  }
+
+  try {
+    const url = new URL(trimmed, baseHref);
+    if (url.protocol === 'http:' || url.protocol === 'ws:') {
+      url.protocol = 'ws:';
+    } else if (url.protocol === 'https:' || url.protocol === 'wss:') {
+      url.protocol = 'wss:';
+    } else {
+      return null;
+    }
+    return url.toString();
+  } catch (err) {
+    console.error('Failed to normalize relay URL', err);
+    return null;
+  }
+}
+
+export function buildReqs({ addr, eventId, limit, until }) {
+  const reqs = [];
+  const subA = randomSubId();
+  const filterA = { kinds: [1, 7], '#a': [addr] };
+  if (Number.isFinite(limit) && limit > 0) {
+    filterA.limit = Math.floor(limit);
+  }
+  if (Number.isFinite(until) && until > 0) {
+    filterA.until = Math.floor(until);
+  }
+  reqs.push({
+    id: subA,
+    frame: ['REQ', subA, filterA],
+  });
+  if (eventId) {
+    const subE = randomSubId();
+    const filterE = { kinds: [1, 7], '#e': [eventId] };
+    if (Number.isFinite(limit) && limit > 0) {
+      filterE.limit = Math.floor(limit);
+    }
+    if (Number.isFinite(until) && until > 0) {
+      filterE.until = Math.floor(until);
+    }
+    reqs.push({
+      id: subE,
+      frame: ['REQ', subE, filterE],
+    });
+  }
+  return reqs;
+}
+
+export function bucketReaction(evt, counts) {
+  const map = counts instanceof Map ? counts : new Map();
+  const emojiTag = evt?.tags?.find((t) => Array.isArray(t) && t[0] === 'emoji' && t[1]);
+  const key = (emojiTag?.[1] || evt?.content || '+').trim() || '+';
+  const total = (map.get(key) || 0) + 1;
+  map.set(key, total);
+  if (!(counts instanceof Map) && counts) {
+    counts[key] = total;
+  }
+  return { key, total, map };
+}
+
+export function dedupe(id, seen) {
+  if (!id) return false;
+  if (seen.has(id)) return false;
+  seen.add(id);
+  return true;
+}
+
+export function formatRelativeTime(timestampMs, nowMs = Date.now()) {
+  if (!Number.isFinite(timestampMs) || !Number.isFinite(nowMs)) return '';
+  const diff = nowMs - timestampMs;
+  const abs = Math.abs(diff);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const week = 7 * day;
+
+  if (abs < minute) {
+    const seconds = Math.max(1, Math.round(abs / 1000));
+    return diff >= 0 ? `${seconds}s ago` : `in ${seconds}s`;
+  }
+  if (abs < hour) {
+    const minutes = Math.round(abs / minute);
+    return diff >= 0 ? `${minutes}m ago` : `in ${minutes}m`;
+  }
+  if (abs < day) {
+    const hours = Math.round(abs / hour);
+    return diff >= 0 ? `${hours}h ago` : `in ${hours}h`;
+  }
+  if (abs < week) {
+    const days = Math.round(abs / day);
+    return diff >= 0 ? `${days}d ago` : `in ${days}d`;
+  }
+  const date = new Date(timestampMs);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toISOString().split('T')[0];
+}
+
+function abbreviatePubkey(pubkey) {
+  if (typeof pubkey !== 'string' || pubkey.length < 8) return pubkey || '';
+  return `${pubkey.slice(0, 8)}…${pubkey.slice(-4)}`;
+}
+
+function renderReply(doc, container, evt, options = {}) {
+  if (!container) return;
+  const article = doc.createElement('article');
+  if (evt.id) {
+    article.dataset.eventId = evt.id;
+  }
+
+  const header = doc.createElement('header');
+  if (evt.pubkey) {
+    const who = doc.createElement('span');
+    who.className = 'reply-author';
+    who.textContent = abbreviatePubkey(evt.pubkey);
+    header.append(who);
+  }
+  let createdAtMs = null;
+  if (evt.created_at) {
+    const time = doc.createElement('time');
+    const timestampMs = Number(evt.created_at) * 1000;
+    if (Number.isFinite(timestampMs)) {
+      createdAtMs = timestampMs;
+      const iso = new Date(timestampMs).toISOString();
+      time.setAttribute('datetime', iso);
+      time.textContent = formatRelativeTime(timestampMs);
+      article.dataset.createdAt = String(timestampMs);
+    }
+    header.append(time);
+  }
+  if (header.childNodes.length) {
+    article.append(header);
+  }
+
+  const body = doc.createElement('div');
+  body.className = 'reply-body';
+  const text = typeof evt.content === 'string' ? evt.content : '';
+  const blocks = text.split(/\n{2,}/);
+  if (blocks.length === 0) {
+    const paragraph = doc.createElement('p');
+    paragraph.append(doc.createTextNode(''));
+    body.append(paragraph);
+  } else {
+    for (const block of blocks) {
+      const paragraph = doc.createElement('p');
+      const lines = block.split('\n');
+      lines.forEach((line, idx) => {
+        paragraph.append(doc.createTextNode(line));
+        if (idx < lines.length - 1) {
+          paragraph.append(doc.createElement('br'));
+        }
+      });
+      body.append(paragraph);
+    }
+  }
+  article.append(body);
+  const append = options.append === true;
+  const placeAtEnd = () => {
+    if (typeof container.append === 'function') {
+      container.append(article);
+    } else {
+      container.insertBefore(article, null);
+    }
+  };
+  if (append) {
+    placeAtEnd();
+    return;
+  }
+  if (Number.isFinite(createdAtMs)) {
+    const children = Array.isArray(container.children)
+      ? container.children
+      : Array.from(container.children || container.childNodes || []);
+    for (const child of children) {
+      if (!child || typeof child !== 'object') continue;
+      const value = Number(child.dataset?.createdAt);
+      if (!Number.isFinite(value)) continue;
+      if (value <= createdAtMs) {
+        container.insertBefore(article, child);
+        return;
+      }
+    }
+    placeAtEnd();
+    return;
+  }
+  if (typeof container.prepend === 'function') {
+    container.prepend(article);
+  } else {
+    container.insertBefore(article, container.firstChild || null);
+  }
+}
+
+function updateReactions(doc, container, evt, counts) {
+  if (!container) return;
+  const { key, total } = bucketReaction(evt, counts);
+  let target = null;
+  const nodes = container.querySelectorAll('[data-reaction]');
+  for (const node of nodes) {
+    if (node.dataset?.reaction === key) {
+      target = node;
+      break;
+    }
+  }
+  if (!target) {
+    target = doc.createElement('span');
+    target.dataset.reaction = key;
+    target.textContent = '0';
+    container.append(target);
+  }
+  target.textContent = String(total);
+}
+
+function showUnavailable(doc) {
+  if (!doc?.body) return;
+  const loadMore = typeof doc.getElementById === 'function' ? doc.getElementById('load-more') : null;
+  if (loadMore) {
+    loadMore.disabled = true;
+  }
+  if (doc.getElementById('live-unavailable')) return;
+  const banner = doc.createElement('div');
+  banner.id = 'live-unavailable';
+  banner.setAttribute('role', 'status');
+  banner.textContent = 'Live view unavailable.';
+  if (typeof doc.body.prepend === 'function') {
+    doc.body.prepend(banner);
+  } else {
+    doc.body.insertBefore(banner, doc.body.firstChild || null);
+  }
+}
+
+function trapFocus(dlg, doc) {
+  const handler = (event) => {
+    if (event.key === 'Tab') {
+      const focusable = Array.from(dlg.querySelectorAll(FOCUSABLE_SELECTOR)).filter((el) => !el.disabled);
+      if (focusable.length === 0) return;
+      const active = doc.activeElement;
+      let idx = focusable.indexOf(active);
+      if (idx === -1) {
+        idx = 0;
+      }
+      event.preventDefault();
+      if (event.shiftKey) {
+        idx = idx <= 0 ? focusable.length - 1 : idx - 1;
+      } else {
+        idx = idx === focusable.length - 1 ? 0 : idx + 1;
+      }
+      focusable[idx].focus();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      dlg.close('cancel');
+    }
+  };
+  dlg.addEventListener('keydown', handler);
+  return () => dlg.removeEventListener('keydown', handler);
+}
+
+async function openReplyDialog({ addr, authorPubkey, eventId, relays, doc, win, trigger }) {
+  const dlg = doc.createElement('dialog');
+  dlg.id = REPLY_DIALOG_ID;
+  dlg.setAttribute('aria-modal', 'true');
+
+  const form = doc.createElement('form');
+  form.setAttribute('method', 'dialog');
+  const textarea = doc.createElement('textarea');
+  textarea.required = true;
+  textarea.setAttribute('aria-label', 'Write a reply');
+
+  const actions = doc.createElement('div');
+  const send = doc.createElement('button');
+  send.type = 'submit';
+  send.textContent = 'Send';
+  const cancel = doc.createElement('button');
+  cancel.type = 'button';
+  cancel.textContent = 'Cancel';
+  cancel.addEventListener('click', () => dlg.close('cancel'));
+
+  actions.append(send, cancel);
+  form.append(textarea, actions);
+  dlg.append(form);
+  doc.body.append(dlg);
+
+  const releaseFocus = trapFocus(dlg, doc);
+
+  const cleanup = () => {
+    if (releaseFocus) releaseFocus();
+    dlg.remove();
+    if (trigger) {
+      trigger.setAttribute('aria-expanded', 'false');
+      if (typeof trigger.focus === 'function') {
+        trigger.focus();
+      }
+    }
+  };
+
+  dlg.addEventListener('close', cleanup, { once: true });
+  dlg.addEventListener('cancel', (event) => {
+    event.preventDefault();
+    dlg.close('cancel');
+  });
+
+  if (trigger) {
+    trigger.setAttribute('aria-controls', REPLY_DIALOG_ID);
+    trigger.setAttribute('aria-expanded', 'true');
+  }
+
+  dlg.showModal();
+  textarea.focus();
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const content = textarea.value.trim();
+    if (!content) return;
+
+    const nostr = win.nostr;
+    if (!nostr?.signEvent) {
+      dlg.close('cancel');
+      return;
+    }
+
+    const reply = {
+      kind: 1,
+      content,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [["a", addr]],
+    };
+    if (authorPubkey) {
+      reply.tags.push(["p", authorPubkey]);
+    }
+    if (eventId) {
+      reply.tags.push(["e", eventId, "", "root"]);
+    }
+
+    try {
+      const signed = await nostr.signEvent(reply);
+      await Promise.all(
+        relays.map(
+          (url) =>
+            new Promise((resolve) => {
+              let socket;
+              try {
+                socket = new win.WebSocket(url);
+              } catch (err) {
+                console.error('Failed to open relay', err);
+                resolve();
+                return;
+              }
+              const finalize = () => {
+                socket.removeEventListener('close', finalize);
+                socket.removeEventListener('error', finalize);
+                resolve();
+              };
+              socket.addEventListener('open', () => {
+                socket.send(JSON.stringify(["EVENT", signed]));
+                socket.close();
+              });
+              socket.addEventListener('close', finalize);
+              socket.addEventListener('error', finalize);
+            })
+        )
+      );
+      dlg.close('sent');
+    } catch (err) {
+      console.error('Failed to publish reply', err);
+      showUnavailable(doc);
+      dlg.close('error');
+    }
+  });
+}
+
+export function start(doc = document, win = window) {
+  const body = doc?.body;
+  if (!body) return;
+  const addr = body.dataset?.addr;
+  if (!addr) return;
+  const eventId = body.dataset?.eventId;
+  const authorPubkey = body.dataset?.authorPubkey || '';
+  const limit = Number.parseInt(body.dataset?.limit || '80', 10) || 80;
+  const showReply = body.dataset?.showReply === '1';
+  const replyButton = doc.getElementById('reply-btn');
+  const replies = doc.getElementById('replies');
+  const loadMoreButton = doc.getElementById('load-more');
+  if (loadMoreButton) {
+    loadMoreButton.disabled = true;
+    if (!loadMoreButton.hasAttribute('aria-controls')) {
+      loadMoreButton.setAttribute('aria-controls', 'replies');
+    }
+  }
+  const markRepliesBusy = (busy) => {
+    if (!replies) return;
+    if (busy) {
+      replies.setAttribute('aria-busy', 'true');
+    } else {
+      replies.removeAttribute('aria-busy');
+    }
+  };
+  markRepliesBusy(false);
+  let replyClickBound = false;
+
+  if (!win || typeof win.WebSocket !== 'function') {
+    markRepliesBusy(false);
+    showUnavailable(doc);
+    return;
+  }
+
+  let relays = [];
+  try {
+    const parsed = JSON.parse(body.dataset?.relays || '[]');
+    if (Array.isArray(parsed)) {
+      relays = parsed.filter((entry) => typeof entry === 'string' && entry.trim().length > 0);
+    }
+  } catch (err) {
+    console.error('Failed to parse relay list', err);
+    markRepliesBusy(false);
+    showUnavailable(doc);
+    return;
+  }
+  const normalizedRelays = [];
+  for (const entry of relays) {
+    const normalized = normalizeRelayUrl(entry, win);
+    if (normalized && !normalizedRelays.includes(normalized)) {
+      normalizedRelays.push(normalized);
+    }
+  }
+  if (normalizedRelays.length === 0) {
+    markRepliesBusy(false);
+    showUnavailable(doc);
+    return;
+  }
+
+  const handleReplyClick = () =>
+    openReplyDialog({ addr, authorPubkey, eventId, relays: normalizedRelays, doc, win, trigger: replyButton });
+
+  let replyPollHandle = null;
+  let nostrReadyHandler = null;
+  let focusHandler = null;
+
+  const cleanupReplyWatchers = () => {
+    if (replyPollHandle !== null && typeof win.clearInterval === 'function') {
+      win.clearInterval(replyPollHandle);
+    }
+    replyPollHandle = null;
+    if (nostrReadyHandler && typeof win.removeEventListener === 'function') {
+      win.removeEventListener('nostr:ready', nostrReadyHandler);
+    }
+    nostrReadyHandler = null;
+    if (focusHandler && typeof win.removeEventListener === 'function') {
+      win.removeEventListener('focus', focusHandler);
+    }
+    focusHandler = null;
+  };
+
+  const ensureReplyEnabled = () => {
+    if (!showReply || !replyButton) return false;
+    if (normalizedRelays.length === 0) return false;
+    const nostr = win.nostr;
+    if (!nostr || typeof nostr.signEvent !== 'function') return false;
+    if (replyButton.hidden) {
+      replyButton.hidden = false;
+    }
+    if (replyButton.getAttribute('aria-haspopup') !== 'dialog') {
+      replyButton.setAttribute('aria-haspopup', 'dialog');
+    }
+    replyButton.setAttribute('aria-controls', REPLY_DIALOG_ID);
+    if (!replyButton.hasAttribute('aria-expanded')) {
+      replyButton.setAttribute('aria-expanded', 'false');
+    }
+    if (!replyClickBound) {
+      replyButton.addEventListener('click', handleReplyClick);
+      replyClickBound = true;
+    }
+    cleanupReplyWatchers();
+    return true;
+  };
+
+  const startReplyWatchers = () => {
+    if (!showReply || !replyButton) return;
+    if (replyPollHandle !== null || nostrReadyHandler || focusHandler) return;
+    if (ensureReplyEnabled()) return;
+    if (typeof win.addEventListener === 'function') {
+      nostrReadyHandler = () => {
+        ensureReplyEnabled();
+      };
+      win.addEventListener('nostr:ready', nostrReadyHandler);
+      focusHandler = () => {
+        ensureReplyEnabled();
+      };
+      win.addEventListener('focus', focusHandler);
+    }
+    if (typeof win.setInterval === 'function' && typeof win.clearInterval === 'function') {
+      const pollDelay = 500;
+      replyPollHandle = win.setInterval(() => {
+        if (ensureReplyEnabled()) {
+          cleanupReplyWatchers();
+        }
+      }, pollDelay);
+    } else {
+      ensureReplyEnabled();
+    }
+  };
+
+  startReplyWatchers();
+
+  const CONNECTING_STATE = win.WebSocket?.CONNECTING ?? 0;
+  const OPEN_STATE = win.WebSocket?.OPEN ?? 1;
+  const CLOSING_STATE = win.WebSocket?.CLOSING ?? 2;
+  const CLOSED_STATE = win.WebSocket?.CLOSED ?? 3;
+
+  const seen = new Set();
+  const reactionContainer = doc.getElementById('reactions');
+  const reactionCounts = new Map();
+  if (reactionContainer) {
+    const spans = reactionContainer.querySelectorAll('[data-reaction]');
+    for (const span of spans) {
+      const key = span.dataset?.reaction;
+      if (!key) continue;
+      const value = parseInt(span.textContent || '0', 10);
+      reactionCounts.set(key, Number.isNaN(value) ? 0 : value);
+    }
+  }
+  let replyCount = 0;
+  let oldestReplyTimestamp = null;
+  const openSubs = new Set();
+  let loadMoreSubs = null;
+  let loadMoreHadResults = false;
+  let loadMoreExhausted = false;
+  let complete = true;
+  let ws = null;
+  let currentRelayIndex = -1;
+  let intentionallyClosing = false;
+  let reopenOnVisible = false;
+
+  const cleanupSocketHandlers = (socket, handlers) => {
+    if (!socket || !handlers) return;
+    if (handlers.open) socket.removeEventListener('open', handlers.open);
+    if (handlers.message) socket.removeEventListener('message', handlers.message);
+    if (handlers.error) socket.removeEventListener('error', handlers.error);
+    if (handlers.close) socket.removeEventListener('close', handlers.close);
+  };
+
+  const dispatchRequests = (socket, reqs, trackLoad = false) => {
+    if (!socket || socket.readyState !== OPEN_STATE) {
+      complete = openSubs.size === 0;
+      markRepliesBusy(openSubs.size > 0);
+      return;
+    }
+    if (!Array.isArray(reqs) || reqs.length === 0) {
+      complete = openSubs.size === 0;
+      markRepliesBusy(openSubs.size > 0);
+      return;
+    }
+    const loadSet = trackLoad ? new Set() : null;
+    for (const req of reqs) {
+      if (!req || typeof req !== 'object' || !req.frame) continue;
+      if (req.id) {
+        openSubs.add(req.id);
+        if (loadSet) {
+          loadSet.add(req.id);
+        }
+        markRepliesBusy(true);
+      }
+      try {
+        socket.send(JSON.stringify(req.frame));
+      } catch (err) {
+        console.error('Failed to send REQ', err);
+      }
+    }
+    if (loadSet) {
+      loadMoreSubs = loadSet;
+      loadMoreHadResults = false;
+    }
+    complete = openSubs.size === 0;
+    markRepliesBusy(openSubs.size > 0);
+  };
+
+  const connectToRelay = (startIndex = 0) => {
+    if (normalizedRelays.length === 0) {
+      markRepliesBusy(false);
+      showUnavailable(doc);
+      return;
+    }
+    const order = [];
+    for (let i = startIndex; i < normalizedRelays.length; i += 1) {
+      order.push(i);
+    }
+    for (let i = 0; i < startIndex; i += 1) {
+      order.push(i);
+    }
+    for (const idx of order) {
+      const url = normalizedRelays[idx];
+      let socket;
+      try {
+        socket = new win.WebSocket(url);
+      } catch (err) {
+        console.error('Failed to open relay', err);
+        continue;
+      }
+      currentRelayIndex = idx;
+      intentionallyClosing = false;
+      const handlers = {};
+      let opened = false;
+
+      handlers.open = () => {
+        opened = true;
+        reopenOnVisible = false;
+        openSubs.clear();
+        loadMoreSubs = null;
+        complete = true;
+        if (loadMoreButton) {
+          loadMoreButton.disabled = true;
+        }
+        dispatchRequests(socket, buildReqs({ addr, eventId, limit }));
+      };
+
+      handlers.message = (event) => {
+        let payload;
+        try {
+          payload = JSON.parse(event.data);
+        } catch (err) {
+          console.error('Ignoring malformed message', err);
+          return;
+        }
+        if (!Array.isArray(payload)) return;
+        const type = payload[0];
+        const sub = payload[1];
+        if (type === 'EVENT') {
+          const evt = payload[2];
+          if (!evt || typeof evt !== 'object') return;
+          if (!dedupe(evt.id, seen)) return;
+          if (evt.kind === 1) {
+            const fromLoadMore = loadMoreSubs?.has(sub) === true;
+            if (fromLoadMore) {
+              loadMoreHadResults = true;
+            }
+            const append = fromLoadMore;
+            renderReply(doc, replies, evt, { append });
+            replyCount += 1;
+            const created = Number(evt.created_at);
+            if (Number.isFinite(created)) {
+              const timestampMs = created * 1000;
+              if (oldestReplyTimestamp === null || timestampMs < oldestReplyTimestamp) {
+                oldestReplyTimestamp = timestampMs;
+                if (loadMoreExhausted) {
+                  loadMoreExhausted = false;
+                }
+              }
+            }
+            if (loadMoreButton) {
+              if (replyCount >= limit && !loadMoreExhausted) {
+                loadMoreButton.hidden = false;
+                if (!loadMoreSubs) {
+                  loadMoreButton.disabled = false;
+                }
+              } else if (loadMoreExhausted) {
+                loadMoreButton.hidden = true;
+                loadMoreButton.disabled = true;
+              }
+            }
+          } else if (evt.kind === 7) {
+            updateReactions(doc, reactionContainer, evt, reactionCounts);
+          }
+        } else if (type === 'EOSE') {
+          if (typeof sub === 'string' && openSubs.has(sub)) {
+            openSubs.delete(sub);
+            complete = openSubs.size === 0;
+            if (openSubs.size === 0) {
+              markRepliesBusy(false);
+            }
+            if (socket.readyState === OPEN_STATE) {
+              try {
+                socket.send(JSON.stringify(['CLOSE', sub]));
+              } catch (err) {
+                console.error('Failed to close subscription', err);
+              }
+            }
+          }
+          if (loadMoreSubs?.has(sub)) {
+            loadMoreSubs.delete(sub);
+            if (loadMoreSubs.size === 0) {
+              loadMoreSubs = null;
+              if (loadMoreHadResults) {
+                if (loadMoreButton) {
+                  loadMoreButton.disabled = false;
+                }
+              } else {
+                loadMoreExhausted = true;
+                if (loadMoreButton) {
+                  loadMoreButton.hidden = true;
+                  loadMoreButton.disabled = true;
+                }
+              }
+              loadMoreHadResults = false;
+            }
+          }
+          markRepliesBusy(openSubs.size > 0);
+        }
+      };
+
+      handlers.error = () => {
+        if (intentionallyClosing) return;
+        cleanupSocketHandlers(socket, handlers);
+        if (!opened) {
+          try {
+            if (socket.readyState === OPEN_STATE || socket.readyState === CONNECTING_STATE) {
+              socket.close();
+            }
+          } catch (err) {
+            console.error('Failed to close failed relay', err);
+          }
+          ws = null;
+          connectToRelay(idx + 1);
+        } else {
+          markRepliesBusy(false);
+          showUnavailable(doc);
+        }
+      };
+
+      handlers.close = () => {
+        cleanupSocketHandlers(socket, handlers);
+        if (ws === socket) {
+          ws = null;
+        }
+        if (intentionallyClosing) {
+          intentionallyClosing = false;
+          return;
+        }
+        if (!opened) {
+          connectToRelay(idx + 1);
+        } else if (!complete) {
+          markRepliesBusy(false);
+          showUnavailable(doc);
+        }
+      };
+
+      socket.addEventListener('open', handlers.open);
+      socket.addEventListener('message', handlers.message);
+      socket.addEventListener('error', handlers.error);
+      socket.addEventListener('close', handlers.close);
+
+      ws = socket;
+      return;
+    }
+    markRepliesBusy(false);
+    showUnavailable(doc);
+  };
+
+  connectToRelay(0);
+
+  const closeSocket = ({ reopen = false, teardownReply = false } = {}) => {
+    if (teardownReply) {
+      cleanupReplyWatchers();
+    }
+    reopenOnVisible = reopen;
+    markRepliesBusy(false);
+    if (!ws) return;
+    intentionallyClosing = true;
+    try {
+      if (ws.readyState === CONNECTING_STATE || ws.readyState === OPEN_STATE || ws.readyState === CLOSING_STATE) {
+        ws.close();
+      }
+    } catch (err) {
+      console.error('Failed to close relay', err);
+    }
+  };
+
+  win.addEventListener('pagehide', () => closeSocket({ teardownReply: true }));
+  doc.addEventListener('visibilitychange', () => {
+    if (doc.visibilityState === 'hidden') {
+      closeSocket({ reopen: true });
+    } else if (doc.visibilityState === 'visible' && reopenOnVisible) {
+      if (!ws || ws.readyState === CLOSED_STATE) {
+        const start = currentRelayIndex >= 0 ? currentRelayIndex : 0;
+        connectToRelay(start);
+      }
+      reopenOnVisible = false;
+      if (replyButton && replyButton.hidden) {
+        if (!ensureReplyEnabled()) {
+          startReplyWatchers();
+        }
+      }
+    }
+  });
+
+  if (loadMoreButton) {
+    loadMoreButton.addEventListener('click', () => {
+      if (loadMoreButton.disabled) return;
+      if (loadMoreExhausted) return;
+      if (loadMoreSubs && loadMoreSubs.size > 0) return;
+      if (oldestReplyTimestamp === null) return;
+      const untilSeconds = Math.floor(oldestReplyTimestamp / 1000) - 1;
+      if (!Number.isFinite(untilSeconds) || untilSeconds <= 0) return;
+      if (!ws || ws.readyState !== OPEN_STATE) return;
+      loadMoreButton.disabled = true;
+      const moreReqs = buildReqs({ addr, eventId, limit, until: untilSeconds });
+      dispatchRequests(ws, moreReqs, true);
+    });
+  }
+
+  }
+
+if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => start(document, window), { once: true });
+  } else {
+    start(document, window);
+  }
+}
+
+export default { start, buildReqs, bucketReaction, dedupe, formatRelativeTime, normalizeRelayUrl };

--- a/core/templates/header.html
+++ b/core/templates/header.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
-<head><meta charset="utf-8"><title>Snort</title></head>
+<head>
+  <meta charset="utf-8">
+  <title>Snort</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src __CONNECT_SRC__; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'">
+</head>
 <body>
 <header><h1>Snort</h1></header>
-

--- a/core/tests/fixtures/index.html
+++ b/core/tests/fixtures/index.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
 <html>
-<head><meta charset="utf-8"><title>Snort</title></head>
+<head>
+  <meta charset="utf-8">
+  <title>Snort</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'">
+</head>
 <body>
 <header><h1>Snort</h1></header>
-
 <ul>
   <li><a href="/posts/test-post/">Hello</a></li>
 </ul>

--- a/core/tests/fixtures/test-post.html
+++ b/core/tests/fixtures/test-post.html
@@ -1,11 +1,24 @@
 <!DOCTYPE html>
 <html>
-<head><meta charset="utf-8"><title>Snort</title></head>
-<body>
+<head>
+  <meta charset="utf-8">
+  <title>Snort</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; font-src 'self'; script-src 'self'">
+</head>
+<body data-event-id="" data-addr="30023:author:test-post" data-author-pubkey="author" data-relays="[&quot;/nostr&quot;]" data-limit="80" data-show-reply="1">
 <header><h1>Snort</h1></header>
-
+<main>
 <h1 id="hello">Hello</h1>
 <p>Body</p>
+</main>
+<aside id="reactions" aria-label="Reactions">
+  <span data-reaction="+">0</span>
+  <span data-reaction="❤️">0</span>
+</aside>
+<section id="replies" aria-live="polite"></section>
+<button id="load-more" hidden>Load more</button>
+<button id="reply-btn" hidden>Reply</button>
+<script type="module" src="/static/js/snort.js" defer></script>
 <footer><p>Footer</p></footer>
 </body>
 </html>

--- a/core/tests/render_from_cache.bats
+++ b/core/tests/render_from_cache.bats
@@ -7,13 +7,13 @@ setup() {
   CACHE_DIR="$ROOT_DIR/cache"
   mkdir -p "$CACHE_DIR/nostr-cache/posts"
   cat > "$CACHE_DIR/nostr-cache/posts/hello.json" << 'JSON'
-{"content": "# Hello\n\nBody", "tags": [["t","intro"],["t","welcome"]], "pubkey": "alice"}
+{"id":"evt1","content": "# Hello\n\nBody", "tags": [["t","intro"],["t","welcome"]], "pubkey": "alice"}
 JSON
   cat > "$CACHE_DIR/nostr-cache/posts/second.json" << 'JSON'
-{"content": "# Second\n\nMore", "tags": [["t","intro"]], "pubkey": "bob"}
+{"id":"evt2","content": "# Second\n\nMore", "tags": [["t","intro"]], "pubkey": "bob"}
 JSON
   cat > "$CACHE_DIR/nostr-cache/posts/third.json" << 'JSON'
-{"content": "# Third\n\nExtra", "tags": [["t","intro"]], "pubkey": "alice"}
+{"id":"evt3","content": "# Third\n\nExtra", "tags": [["t","intro"]], "pubkey": "alice"}
 JSON
   cat > "$CACHE_DIR/nostr-cache/index.json" << 'JSON'
 ["hello","second"]
@@ -24,7 +24,7 @@ EOF2
 }
 
 teardown() {
-  rm -rf public cache .env
+  rm -rf public cache .env custom-static
 }
 
 @test "render_from_cache builds index, posts, tags, authors" {
@@ -42,6 +42,18 @@ teardown() {
   grep -q '<h1 id="second">Second</h1>' public/posts/second/index.html
   [ ! -f public/posts/third/index.html ]
 
+  grep -q 'data-addr="30023:alice:hello"' public/posts/hello/index.html
+  grep -F 'data-relays="[&quot;/nostr&quot;]"' public/posts/hello/index.html
+  grep -q '<aside id="reactions"' public/posts/hello/index.html
+  grep -q '<section id="replies"' public/posts/hello/index.html
+  grep -q '<button id="load-more" hidden>Load more</button>' public/posts/hello/index.html
+  grep -q '<button id="reply-btn" hidden>Reply</button>' public/posts/hello/index.html
+  grep -q '<script type="module" src="/static/js/snort.js" defer></script>' public/posts/hello/index.html
+  grep -q "Content-Security-Policy" public/posts/hello/index.html
+  grep -q "connect-src 'self'" public/posts/hello/index.html
+  ! grep -q '__CONNECT_SRC__' public/posts/hello/index.html
+  [ -f public/static/js/snort.js ]
+
   [ -f public/tags/intro/index.html ]
   [ -f public/tags/welcome/index.html ]
   grep -q '/posts/hello/' public/tags/intro/index.html
@@ -54,4 +66,52 @@ teardown() {
   grep -q '/posts/hello/' public/authors/alice/index.html
   grep -q '/posts/second/' public/authors/bob/index.html
   ! grep -q '/posts/third/' public/authors/alice/index.html
+}
+
+@test "interactivity disabled when INTERACT_ENABLE=0" {
+  cat >> .env << 'ENV'
+INTERACT_ENABLE=0
+ENV
+  run scripts/render_from_cache.sh
+  [ "$status" -eq 0 ]
+  ! grep -q '/static/js/snort.js' public/posts/hello/index.html
+}
+
+@test "CSP connect-src lists configured relay" {
+  cat >> .env << 'ENV'
+INTERACT_RELAYS='["wss://relay.example"]'
+ENV
+  run scripts/render_from_cache.sh
+  [ "$status" -eq 0 ]
+  grep -q "connect-src 'self' wss://relay.example" public/posts/hello/index.html
+}
+
+@test "CSP connect-src normalizes duplicates and schemes" {
+  cat >> .env << 'ENV'
+INTERACT_RELAYS='["https://relay.example","wss://relay.example","/nostr","http://localhost:7777"]'
+ENV
+  run scripts/render_from_cache.sh
+  [ "$status" -eq 0 ]
+  grep -q "connect-src 'self' wss://relay.example ws://localhost:7777" public/posts/hello/index.html
+}
+
+@test "interactivity attributes escape special characters" {
+  cat >> .env << 'ENV'
+INTERACT_RELAYS='["wss://relay.example/path?token=\"abc\"&q=1","wss://other.example/?x=<tag>"]'
+ENV
+  run scripts/render_from_cache.sh
+  [ "$status" -eq 0 ]
+  grep -F 'data-relays="[&quot;wss://relay.example/path?token=\&quot;abc\&quot;&amp;q=1&quot;' public/posts/hello/index.html
+  grep -F '&lt;tag&gt;' public/posts/hello/index.html
+}
+
+@test "static assets copy tolerates dotfiles only" {
+  mkdir -p custom-static
+  touch custom-static/.keep
+  cat >> .env << EOF
+STATIC_SRC="$PWD/custom-static"
+EOF
+  run scripts/render_from_cache.sh
+  [ "$status" -eq 0 ]
+  [ -f public/static/.keep ]
 }

--- a/core/tests/snort.integration.test.mjs
+++ b/core/tests/snort.integration.test.mjs
@@ -1,0 +1,1239 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+class FakeNode extends EventTarget {
+  constructor(doc) {
+    super();
+    this.ownerDocument = doc;
+    this.parentNode = null;
+    this.childNodes = [];
+  }
+}
+
+class FakeText extends FakeNode {
+  constructor(doc, value) {
+    super(doc);
+    this.text = value;
+  }
+
+  get textContent() {
+    return this.text;
+  }
+
+  set textContent(value) {
+    this.text = String(value);
+  }
+}
+
+function createDatasetProxy(element) {
+  const store = {};
+  return new Proxy(store, {
+    set(target, prop, value) {
+      target[prop] = String(value);
+      element._attributes.set(`data-${String(prop)}`, String(value));
+      return true;
+    },
+    get(target, prop) {
+      return target[prop];
+    },
+    deleteProperty(target, prop) {
+      delete target[prop];
+      element._attributes.delete(`data-${String(prop)}`);
+      return true;
+    },
+  });
+}
+
+class FakeElement extends FakeNode {
+  constructor(tagName, doc) {
+    super(doc);
+    this.tagName = tagName.toUpperCase();
+    this._attributes = new Map();
+    this.dataset = createDatasetProxy(this);
+    this._id = "";
+    this.className = "";
+    if (this.tagName === "TEXTAREA") {
+      this.value = "";
+    }
+  }
+
+  get id() {
+    return this._id;
+  }
+
+  set id(value) {
+    const idStr = String(value);
+    if (this._id === idStr) return;
+    if (this.ownerDocument) {
+      this.ownerDocument._unregisterId(this);
+    }
+    this._id = idStr;
+    if (idStr && this.ownerDocument) {
+      this.ownerDocument._registerId(idStr, this);
+    }
+    if (idStr) {
+      this._attributes.set("id", idStr);
+    } else {
+      this._attributes.delete("id");
+    }
+  }
+
+  setAttribute(name, value) {
+    const val = String(value);
+    if (name === "id") {
+      this.id = val;
+      return;
+    }
+    if (name === "class") {
+      this.className = val;
+    }
+    this._attributes.set(name, val);
+    if (name.startsWith("data-")) {
+      const key = name.slice(5);
+      this.dataset[key] = val;
+    }
+  }
+
+  removeAttribute(name) {
+    if (name === "id") {
+      this.id = "";
+      return;
+    }
+    if (name === "class") {
+      this.className = "";
+    }
+    this._attributes.delete(name);
+    if (name.startsWith("data-")) {
+      const key = name.slice(5);
+      delete this.dataset[key];
+    }
+  }
+
+  getAttribute(name) {
+    return this._attributes.has(name) ? this._attributes.get(name) : null;
+  }
+
+  hasAttribute(name) {
+    return this._attributes.has(name);
+  }
+
+  append(...nodes) {
+    for (const node of nodes) {
+      this._insertNode(node, this.childNodes.length);
+    }
+  }
+
+  appendChild(node) {
+    this._insertNode(node, this.childNodes.length);
+    return node;
+  }
+
+  prepend(...nodes) {
+    let index = 0;
+    for (const node of nodes) {
+      this._insertNode(node, index);
+      index += 1;
+    }
+  }
+
+  insertBefore(node, reference) {
+    const refIndex = reference ? this.childNodes.indexOf(reference) : -1;
+    const index = refIndex >= 0 ? refIndex : this.childNodes.length;
+    this._insertNode(node, index);
+    return node;
+  }
+
+  _insertNode(node, index) {
+    const adopted = this._normalizeNode(node);
+    if (adopted.parentNode) {
+      adopted.parentNode._removeChild(adopted);
+    }
+    adopted.parentNode = this;
+    this.childNodes.splice(index, 0, adopted);
+  }
+
+  _normalizeNode(node) {
+    if (typeof node === "string") {
+      return this.ownerDocument.createTextNode(node);
+    }
+    return node;
+  }
+
+  _removeChild(child) {
+    const idx = this.childNodes.indexOf(child);
+    if (idx >= 0) {
+      this.childNodes.splice(idx, 1);
+      child.parentNode = null;
+      if (child instanceof FakeElement && child.ownerDocument) {
+        child.ownerDocument._unregisterId(child);
+      }
+    }
+  }
+
+  remove() {
+    if (this.parentNode) {
+      this.parentNode._removeChild(this);
+    } else if (this.ownerDocument) {
+      this.ownerDocument._unregisterId(this);
+    }
+  }
+
+  get children() {
+    return this.childNodes.filter((child) => child instanceof FakeElement);
+  }
+
+  querySelectorAll(selector) {
+    const selectors = selector.split(",").map((s) => s.trim()).filter(Boolean);
+    const results = [];
+    const matchers = selectors.map((sel) => createMatcher(sel));
+    const visit = (node) => {
+      if (!(node instanceof FakeElement)) return;
+      if (matchers.some((fn) => fn(node))) {
+        results.push(node);
+      }
+      for (const child of node.childNodes) {
+        visit(child);
+      }
+    };
+    for (const child of this.childNodes) {
+      visit(child);
+    }
+    return results;
+  }
+
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+
+  get textContent() {
+    let out = "";
+    for (const child of this.childNodes) {
+      if (child instanceof FakeElement) {
+        out += child.textContent;
+      } else if (child instanceof FakeText) {
+        out += child.textContent;
+      }
+    }
+    return out;
+  }
+
+  set textContent(value) {
+    this.childNodes = [];
+    if (value !== undefined && value !== null) {
+      this.append(String(value));
+    }
+  }
+
+  focus() {
+    if (this.ownerDocument) {
+      this.ownerDocument.activeElement = this;
+    }
+  }
+}
+
+class FakeDialog extends FakeElement {
+  constructor(doc) {
+    super("dialog", doc);
+    this.open = false;
+    this.returnValue = "";
+  }
+
+  showModal() {
+    this.open = true;
+    this.ownerDocument.activeElement = this;
+  }
+
+  close(value = "") {
+    if (!this.open) return;
+    this.returnValue = value;
+    this.open = false;
+    const event = new Event("close");
+    this.dispatchEvent(event);
+  }
+}
+
+class FakeDocument extends EventTarget {
+  constructor() {
+    super();
+    this._ids = new Map();
+    this.body = new FakeElement("body", this);
+    this.visibilityState = "visible";
+    this.readyState = "complete";
+    this.activeElement = null;
+  }
+
+  createElement(tag) {
+    return tag.toLowerCase() === "dialog" ? new FakeDialog(this) : new FakeElement(tag, this);
+  }
+
+  createTextNode(value) {
+    return new FakeText(this, value);
+  }
+
+  getElementById(id) {
+    return this._ids.get(id) || null;
+  }
+
+  _registerId(id, element) {
+    this._ids.set(id, element);
+  }
+
+  _unregisterId(element) {
+    if (!element || !element._id) return;
+    const current = this._ids.get(element._id);
+    if (current === element) {
+      this._ids.delete(element._id);
+    }
+  }
+
+  querySelectorAll(selector) {
+    return this.body.querySelectorAll(selector);
+  }
+
+  querySelector(selector) {
+    return this.body.querySelector(selector);
+  }
+}
+
+class FakeWindow {
+  constructor() {
+    this._listeners = new Map();
+    this.nostr = undefined;
+    this._intervals = new Set();
+  }
+
+  addEventListener(type, handler) {
+    const list = this._listeners.get(type) || [];
+    list.push(handler);
+    this._listeners.set(type, list);
+  }
+
+  removeEventListener(type, handler) {
+    const list = this._listeners.get(type) || [];
+    const idx = list.indexOf(handler);
+    if (idx >= 0) {
+      list.splice(idx, 1);
+    }
+  }
+
+  dispatchEvent(event) {
+    const list = this._listeners.get(event.type) || [];
+    for (const handler of [...list]) {
+      handler.call(this, event);
+    }
+  }
+
+  setInterval(handler, delay) {
+    const id = global.setInterval(handler, delay);
+    this._intervals.add(id);
+    return id;
+  }
+
+  clearInterval(id) {
+    global.clearInterval(id);
+    this._intervals.delete(id);
+  }
+
+  dispose() {
+    for (const id of this._intervals) {
+      global.clearInterval(id);
+    }
+    this._intervals.clear();
+  }
+}
+
+class FakeWebSocket extends EventTarget {
+  constructor(url) {
+    super();
+    this.url = url;
+    this.readyState = FakeWebSocket.CONNECTING;
+    this.sent = [];
+    FakeWebSocket.instances.push(this);
+    const behavior = FakeWebSocket.behaviors.get(url);
+    if (behavior === "fail") {
+      queueMicrotask(() => {
+        this.dispatchEvent(new Event("error"));
+        this.readyState = FakeWebSocket.CLOSING;
+        this.readyState = FakeWebSocket.CLOSED;
+        this.dispatchEvent(new Event("close"));
+      });
+      return;
+    }
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.dispatchEvent(new Event("open"));
+    });
+  }
+
+  send(payload) {
+    this.sent.push(payload);
+  }
+
+  close() {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.dispatchEvent(new Event("close"));
+  }
+
+  emitMessage(data) {
+    this.dispatchEvent(new MessageEvent("message", { data }));
+  }
+
+  emitError() {
+    this.dispatchEvent(new Event("error"));
+  }
+
+  static reset() {
+    FakeWebSocket.instances = [];
+    FakeWebSocket.behaviors = new Map();
+  }
+
+  static setBehavior(url, behavior) {
+    if (!behavior) {
+      FakeWebSocket.behaviors.delete(url);
+    } else {
+      FakeWebSocket.behaviors.set(url, behavior);
+    }
+  }
+}
+
+FakeWebSocket.CONNECTING = 0;
+FakeWebSocket.OPEN = 1;
+FakeWebSocket.CLOSING = 2;
+FakeWebSocket.CLOSED = 3;
+FakeWebSocket.instances = [];
+FakeWebSocket.behaviors = new Map();
+
+function createMatcher(selector) {
+  if (selector === "[data-reaction]") {
+    return (el) => el.dataset && el.dataset.reaction !== undefined;
+  }
+  const match = selector.match(/^\[data-reaction="(.+)"\]$/);
+  if (match) {
+    const [, value] = match;
+    return (el) => el.dataset && el.dataset.reaction === value;
+  }
+  if (selector.startsWith("#")) {
+    const id = selector.slice(1);
+    return (el) => el.id === id;
+  }
+  const tag = selector.toUpperCase();
+  return (el) => el.tagName === tag;
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+function setupDom() {
+  const doc = new FakeDocument();
+  const win = new FakeWindow();
+  win.WebSocket = FakeWebSocket;
+  win.location = {
+    href: 'https://snort.test/posts/test-post',
+    origin: 'https://snort.test',
+    protocol: 'https:',
+    host: 'snort.test',
+  };
+  doc.body.dataset.addr = "30023:pub:test-post";
+  doc.body.dataset.eventId = "root-event";
+  doc.body.dataset.limit = "5";
+  doc.body.dataset.relays = JSON.stringify(["/nostr", "wss://relay.example"]);
+  doc.body.dataset.showReply = "1";
+  doc.body.dataset.authorPubkey = "authorpub";
+
+  const main = doc.createElement("main");
+  doc.body.append(main);
+  const reactions = doc.createElement("aside");
+  reactions.id = "reactions";
+  const plus = doc.createElement("span");
+  plus.dataset.reaction = "+";
+  plus.textContent = "0";
+  const heart = doc.createElement("span");
+  heart.dataset.reaction = "❤️";
+  heart.textContent = "0";
+  reactions.append(plus, heart);
+  doc.body.append(reactions);
+
+  const replies = doc.createElement("section");
+  replies.id = "replies";
+  doc.body.append(replies);
+
+  const loadMore = doc.createElement("button");
+  loadMore.id = "load-more";
+  loadMore.hidden = true;
+  loadMore.disabled = true;
+  doc.body.append(loadMore);
+
+  const replyButton = doc.createElement("button");
+  replyButton.id = "reply-btn";
+  replyButton.hidden = true;
+  doc.body.append(replyButton);
+
+  return { doc, win };
+}
+
+function getArticles(container) {
+  return container.childNodes.filter((node) => node instanceof FakeElement && node.tagName === "ARTICLE");
+}
+
+function ensureMessageEvent() {
+  if (typeof MessageEvent === "undefined") {
+    global.MessageEvent = class MessageEvent extends Event {
+      constructor(type, init = {}) {
+        super(type);
+        this.data = init.data;
+      }
+    };
+  }
+}
+
+function restoreMessageEvent(original) {
+  if (original) {
+    global.MessageEvent = original;
+  } else if (typeof MessageEvent !== "undefined") {
+    delete global.MessageEvent;
+  }
+}
+
+test("start hydrates replies and reactions", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+
+  const { doc, win } = setupDom();
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+    const ws = FakeWebSocket.instances.at(-1);
+    await flush();
+    assert.ok(ws);
+    assert.equal(ws.url, "wss://snort.test/nostr");
+
+    const loadMore = doc.getElementById("load-more");
+    assert.equal(loadMore.getAttribute("aria-controls"), "replies");
+
+    const sentFrames = ws.sent.map((raw) => JSON.parse(raw));
+    assert.equal(sentFrames.length, 2);
+    const subIds = sentFrames.map((frame) => frame[1]);
+    const subA = subIds[0];
+    assert.ok(subA);
+    const subE = subIds[1];
+
+    const replies = doc.getElementById("replies");
+    assert.equal(replies.getAttribute("aria-busy"), "true");
+    assert.equal(getArticles(replies).length, 0);
+
+    ws.emitMessage(JSON.stringify(["EVENT", subA, { id: "react1", kind: 7, content: "🔥", tags: [], created_at: Math.floor(Date.now() / 1000) }]));
+    const reactionSpans = doc.getElementById("reactions").querySelectorAll("[data-reaction]");
+    const flame = reactionSpans.find((el) => el.dataset.reaction === "🔥");
+    assert.ok(flame);
+    assert.equal(flame.textContent, "1");
+
+    const replyEvent = {
+      id: "reply1",
+      kind: 1,
+      content: "<b>Hi</b>\nSecond",
+      pubkey: "abcdef1234567890abcdef1234567890abcdef12",
+      created_at: Math.floor((Date.now() - 90_000) / 1000),
+    };
+    ws.emitMessage(JSON.stringify(["EVENT", subA, replyEvent]));
+    const articles = getArticles(replies);
+    assert.equal(articles.length, 1);
+    const article = articles[0];
+    assert.equal(article.querySelectorAll("script").length, 0);
+    assert.ok(article.textContent.includes("<b>Hi</b>"));
+    const timeEl = article.querySelector("time");
+    assert.ok(timeEl);
+    assert.ok(timeEl.getAttribute("datetime"));
+    assert.ok(timeEl.textContent.length > 0);
+
+    ws.emitMessage(JSON.stringify(["EVENT", subA, replyEvent]));
+    assert.equal(getArticles(replies).length, 1);
+
+    ws.emitMessage(JSON.stringify(["EOSE", subA]));
+    const closeFrame = ws.sent.map((raw) => JSON.parse(raw)).find((frame) => frame[0] === "CLOSE" && frame[1] === subA);
+    assert.ok(closeFrame);
+
+    if (subE) {
+      ws.emitMessage(JSON.stringify(["EOSE", subE]));
+    }
+    await flush();
+    assert.equal(replies.getAttribute("aria-busy"), null);
+
+    ws.emitError();
+    const banner = doc.getElementById("live-unavailable");
+    assert.ok(banner);
+    assert.equal(banner.textContent, "Live view unavailable.");
+
+    const button = doc.getElementById("reply-btn");
+    assert.equal(button.hidden, true);
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+  }
+});
+
+test("replies stay sorted when events arrive out of order", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+
+  const { doc, win } = setupDom();
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+    const ws = FakeWebSocket.instances.at(-1);
+    await flush();
+    assert.ok(ws);
+
+    const sentFrames = ws.sent.map((raw) => JSON.parse(raw));
+    const reqFrames = sentFrames.filter((frame) => frame[0] === "REQ");
+    const subA = reqFrames[0][1];
+    assert.ok(subA);
+
+    const replies = doc.getElementById("replies");
+    ws.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        subA,
+        { id: "reply-new", kind: 1, content: "New", created_at: 200, pubkey: "npub-new" },
+      ])
+    );
+    ws.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        subA,
+        { id: "reply-old", kind: 1, content: "Old", created_at: 100, pubkey: "npub-old" },
+      ])
+    );
+    ws.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        subA,
+        { id: "reply-newest", kind: 1, content: "Newest", created_at: 300, pubkey: "npub-newest" },
+      ])
+    );
+
+    const order = getArticles(replies).map((article) => article.dataset.eventId);
+    assert.deepEqual(order, ["reply-newest", "reply-new", "reply-old"]);
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+  }
+});
+
+test("load more fetches older replies", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+
+  const { doc, win } = setupDom();
+  doc.body.dataset.limit = "2";
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+    const ws = FakeWebSocket.instances.at(-1);
+    await flush();
+    assert.ok(ws);
+
+    const sentFrames = ws.sent.map((raw) => JSON.parse(raw));
+    const reqFrames = sentFrames.filter((frame) => frame[0] === "REQ");
+    assert.equal(reqFrames.length, 2);
+    const subA = reqFrames[0][1];
+    assert.ok(subA);
+    const subE = reqFrames[1][1];
+
+    const loadMore = doc.getElementById("load-more");
+    assert.ok(loadMore);
+    assert.equal(loadMore.hidden, true);
+    assert.equal(loadMore.disabled, true);
+
+    const replies = doc.getElementById("replies");
+    assert.equal(replies.getAttribute("aria-busy"), "true");
+    ws.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        subA,
+        { id: "reply-old", kind: 1, content: "Old", created_at: 100, pubkey: "oldpub" },
+      ])
+    );
+    ws.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        subA,
+        { id: "reply-new", kind: 1, content: "New", created_at: 200, pubkey: "newpub" },
+      ])
+    );
+
+    const initialOrder = getArticles(replies).map((article) => article.dataset.eventId);
+    assert.deepEqual(initialOrder, ["reply-new", "reply-old"]);
+    assert.equal(loadMore.hidden, false);
+    assert.equal(loadMore.disabled, false);
+
+    ws.emitMessage(JSON.stringify(["EOSE", subA]));
+    if (subE) {
+      ws.emitMessage(JSON.stringify(["EOSE", subE]));
+    }
+    await flush();
+    assert.equal(replies.getAttribute("aria-busy"), null);
+
+    loadMore.dispatchEvent(new Event("click"));
+    assert.equal(loadMore.disabled, true);
+    assert.equal(replies.getAttribute("aria-busy"), "true");
+
+    const loadFrames = ws.sent.slice(-2).map((raw) => JSON.parse(raw));
+    const loadReq = loadFrames.find((frame) => frame[2] && frame[2]["#a"]);
+    assert.ok(loadReq);
+    assert.equal(loadReq[2].until, 99);
+    const loadSub = loadReq[1];
+    assert.ok(loadSub);
+
+    ws.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        loadSub,
+        { id: "reply-oldest", kind: 1, content: "Older", created_at: 50, pubkey: "older" },
+      ])
+    );
+
+    const afterLoadOrder = getArticles(replies).map((article) => article.dataset.eventId);
+    assert.deepEqual(afterLoadOrder, ["reply-new", "reply-old", "reply-oldest"]);
+
+    for (const frame of loadFrames) {
+      ws.emitMessage(JSON.stringify(["EOSE", frame[1]]));
+    }
+    await flush();
+    assert.equal(replies.getAttribute("aria-busy"), null);
+    assert.equal(loadMore.disabled, false);
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+  }
+});
+
+test("load more hides when no older replies remain", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+
+  const { doc, win } = setupDom();
+  doc.body.dataset.limit = "2";
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+    const ws = FakeWebSocket.instances.at(-1);
+    await flush();
+    assert.ok(ws);
+
+    const sentFrames = ws.sent.map((raw) => JSON.parse(raw));
+    const reqFrames = sentFrames.filter((frame) => frame[0] === "REQ");
+    assert.equal(reqFrames.length, 2);
+    const subA = reqFrames[0][1];
+    assert.ok(subA);
+    const subE = reqFrames[1][1];
+
+    const replies = doc.getElementById("replies");
+    assert.equal(replies.getAttribute("aria-busy"), "true");
+    const loadMore = doc.getElementById("load-more");
+    assert.ok(loadMore);
+
+    ws.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        subA,
+        { id: "reply-old", kind: 1, content: "Old", created_at: 100, pubkey: "oldpub" },
+      ])
+    );
+    ws.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        subA,
+        { id: "reply-new", kind: 1, content: "New", created_at: 200, pubkey: "newpub" },
+      ])
+    );
+
+    assert.equal(loadMore.hidden, false);
+    assert.equal(loadMore.disabled, false);
+
+    ws.emitMessage(JSON.stringify(["EOSE", subA]));
+    if (subE) {
+      ws.emitMessage(JSON.stringify(["EOSE", subE]));
+    }
+    await flush();
+    assert.equal(replies.getAttribute("aria-busy"), null);
+
+    const beforeLoad = ws.sent.length;
+    loadMore.dispatchEvent(new Event("click"));
+    assert.equal(loadMore.disabled, true);
+    assert.equal(replies.getAttribute("aria-busy"), "true");
+
+    const newFrames = ws.sent
+      .slice(beforeLoad)
+      .map((raw) => JSON.parse(raw))
+      .filter((frame) => frame[0] === "REQ");
+    assert.ok(newFrames.length > 0);
+
+    for (const frame of newFrames) {
+      ws.emitMessage(JSON.stringify(["EOSE", frame[1]]));
+    }
+    await flush();
+    assert.equal(replies.getAttribute("aria-busy"), null);
+
+    assert.equal(loadMore.hidden, true);
+    assert.equal(loadMore.disabled, true);
+
+    const afterHideCount = ws.sent.length;
+    loadMore.dispatchEvent(new Event("click"));
+    assert.equal(ws.sent.length, afterHideCount);
+
+    ws.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        subA,
+        { id: "reply-older", kind: 1, content: "Older", created_at: 50, pubkey: "older" },
+      ])
+    );
+
+    const order = getArticles(replies).map((article) => article.dataset.eventId);
+    assert.deepEqual(order, ["reply-new", "reply-old", "reply-older"]);
+    assert.equal(loadMore.hidden, false);
+    assert.equal(loadMore.disabled, false);
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+  }
+});
+
+test("reply dialog publishes signed events to configured relays", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+
+  const { doc, win } = setupDom();
+  const signedEvents = [];
+  win.nostr = {
+    async signEvent(event) {
+      signedEvents.push(event);
+      return { ...event, id: "signed", sig: "signature", pubkey: "npub" };
+    },
+  };
+
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+
+    const button = doc.getElementById("reply-btn");
+    assert.equal(button.hidden, false);
+    assert.equal(button.getAttribute("aria-haspopup"), "dialog");
+    assert.equal(button.getAttribute("aria-controls"), "reply-dialog");
+    assert.equal(button.getAttribute("aria-expanded"), "false");
+
+    button.dispatchEvent(new Event("click"));
+
+    assert.equal(button.getAttribute("aria-expanded"), "true");
+
+    const dialog = doc.querySelector("#reply-dialog");
+    assert.ok(dialog);
+    const textarea = dialog.querySelector("textarea");
+    assert.equal(doc.activeElement, textarea);
+    textarea.value = "Hello there";
+
+    const form = dialog.querySelector("form");
+    const submitEvent = new Event("submit", { cancelable: true });
+    form.dispatchEvent(submitEvent);
+
+    await flush();
+    await flush();
+
+    assert.equal(signedEvents.length, 1);
+    assert.equal(signedEvents[0].kind, 1);
+    assert.deepEqual(signedEvents[0].tags, [
+      ["a", "30023:pub:test-post"],
+      ["p", "authorpub"],
+      ["e", "root-event", "", "root"],
+    ]);
+
+    const sockets = FakeWebSocket.instances;
+    assert.equal(sockets.length, 3);
+    const publishSockets = sockets.slice(1);
+    const urls = publishSockets.map((socket) => socket.url).sort();
+    assert.deepEqual(urls, ["wss://relay.example/", "wss://snort.test/nostr"]);
+
+    for (const socket of publishSockets) {
+      const frames = socket.sent.map((raw) => JSON.parse(raw));
+      assert.equal(frames.length, 1);
+      assert.equal(frames[0][0], "EVENT");
+      assert.equal(frames[0][1].id, "signed");
+    }
+
+    await flush();
+    assert.equal(button.getAttribute("aria-expanded"), "false");
+    assert.equal(doc.activeElement, button);
+    assert.equal(doc.querySelector("#reply-dialog"), null);
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+  }
+});
+
+test("reply button stays hidden when configuration disables it", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+
+  const { doc, win } = setupDom();
+  doc.body.dataset.showReply = "0";
+  win.nostr = {
+    async signEvent(event) {
+      return event;
+    },
+  };
+
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+
+    const button = doc.getElementById("reply-btn");
+    assert.equal(button.hidden, true);
+    assert.equal(button.hasAttribute("aria-haspopup"), false);
+    assert.equal(button.hasAttribute("aria-controls"), false);
+    assert.equal(button.hasAttribute("aria-expanded"), false);
+    assert.equal(win._listeners.has("nostr:ready"), false);
+    assert.equal(win._listeners.has("focus"), false);
+    assert.equal(win._intervals.size, 0);
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+  }
+});
+
+test("reply button appears when nostr becomes available later", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+
+  const { doc, win } = setupDom();
+
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+
+    const button = doc.getElementById("reply-btn");
+    assert.equal(button.hidden, true);
+
+    win.nostr = {
+      async signEvent(event) {
+        return event;
+      },
+    };
+
+    win.dispatchEvent(new Event("nostr:ready"));
+
+    await flush();
+
+    assert.equal(button.hidden, false);
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+  }
+});
+
+test("reply button polling detects nostr without events", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+  const originalSetInterval = global.setInterval;
+  const originalClearInterval = global.clearInterval;
+
+  const handlers = new Map();
+  const cleared = new Set();
+  let nextId = 1;
+
+  global.setInterval = (fn) => {
+    const id = nextId;
+    nextId += 1;
+    handlers.set(id, fn);
+    return id;
+  };
+
+  global.clearInterval = (id) => {
+    cleared.add(id);
+    handlers.delete(id);
+  };
+
+  const { doc, win } = setupDom();
+
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+
+    const button = doc.getElementById("reply-btn");
+    assert.equal(button.hidden, true);
+    const entries = [...handlers.entries()];
+    assert.equal(entries.length, 1);
+    const [intervalId, tick] = entries[0];
+
+    win.nostr = {
+      async signEvent(event) {
+        return event;
+      },
+    };
+
+    tick();
+
+    await flush();
+
+    assert.equal(button.hidden, false);
+    assert.ok(cleared.has(intervalId));
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+    global.setInterval = originalSetInterval;
+    global.clearInterval = originalClearInterval;
+  }
+});
+
+test("start falls back to next relay when primary fails", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+
+  const { doc, win } = setupDom();
+
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    FakeWebSocket.setBehavior("wss://snort.test/nostr", "fail");
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+    await flush();
+
+    const sockets = FakeWebSocket.instances;
+    assert.ok(sockets.length >= 2);
+    const primary = sockets[0];
+    const fallback = sockets.at(-1);
+    assert.notEqual(primary, fallback);
+    assert.equal(fallback.url, "wss://relay.example/");
+
+    const reqFrames = fallback.sent.map((raw) => JSON.parse(raw)).filter((frame) => frame[0] === "REQ");
+    assert.equal(reqFrames.length, 2);
+    const subId = reqFrames[0][1];
+    assert.ok(subId);
+
+    fallback.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        subId,
+        { id: "fallback-reply", kind: 1, content: "Hi", created_at: Math.floor(Date.now() / 1000), pubkey: "fallback" },
+      ])
+    );
+
+    const replies = doc.getElementById("replies");
+    assert.equal(getArticles(replies).length, 1);
+    assert.equal(doc.getElementById("live-unavailable"), null);
+  } finally {
+    FakeWebSocket.setBehavior("wss://snort.test/nostr", null);
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+  }
+});
+
+test("start reconnects when page becomes visible again", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+  const originalMessageEvent = typeof MessageEvent === "undefined" ? null : MessageEvent;
+
+  const { doc, win } = setupDom();
+
+  global.document = doc;
+  global.window = win;
+  ensureMessageEvent();
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+    const first = FakeWebSocket.instances.at(-1);
+    await flush();
+    assert.ok(first);
+
+    const initialReqs = first.sent.map((raw) => JSON.parse(raw)).filter((frame) => frame[0] === "REQ");
+    assert.ok(initialReqs.length >= 1);
+    const initialSub = initialReqs[0][1];
+    first.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        initialSub,
+        { id: "initial", kind: 1, content: "One", created_at: Math.floor(Date.now() / 1000), pubkey: "first" },
+      ])
+    );
+
+    doc.visibilityState = "hidden";
+    doc.dispatchEvent(new Event("visibilitychange"));
+    await flush();
+    assert.equal(first.readyState, FakeWebSocket.CLOSED);
+
+    doc.visibilityState = "visible";
+    doc.dispatchEvent(new Event("visibilitychange"));
+    await flush();
+
+    const sockets = FakeWebSocket.instances;
+    assert.ok(sockets.length >= 2);
+    const reopened = sockets.at(-1);
+    assert.notEqual(reopened, first);
+    assert.equal(reopened.url, first.url);
+
+    const newReqs = reopened.sent.map((raw) => JSON.parse(raw)).filter((frame) => frame[0] === "REQ");
+    assert.ok(newReqs.length >= 1);
+    const newSub = newReqs[0][1];
+    reopened.emitMessage(
+      JSON.stringify([
+        "EVENT",
+        newSub,
+        { id: "resumed", kind: 1, content: "Two", created_at: Math.floor(Date.now() / 1000), pubkey: "second" },
+      ])
+    );
+
+    const replies = doc.getElementById("replies");
+    const ids = getArticles(replies).map((article) => article.dataset.eventId);
+    assert.deepEqual(ids, ["resumed", "initial"]);
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+    restoreMessageEvent(originalMessageEvent);
+  }
+});
+
+test("start shows banner when WebSocket unsupported", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+
+  const { doc, win } = setupDom();
+  win.WebSocket = undefined;
+
+  global.document = doc;
+  global.window = win;
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+
+    const banner = doc.getElementById("live-unavailable");
+    assert.ok(banner);
+    assert.equal(banner.textContent, "Live view unavailable.");
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+  }
+});
+
+test("start handles invalid relay config", async () => {
+  FakeWebSocket.reset();
+  const originalDocument = global.document;
+  const originalWindow = global.window;
+
+  const { doc, win } = setupDom();
+  doc.body.dataset.relays = "not-json";
+
+  global.document = doc;
+  global.window = win;
+
+  try {
+    const module = await import("../static/js/snort.js");
+    module.start(doc, win);
+
+    await flush();
+
+    const banner = doc.getElementById("live-unavailable");
+    assert.ok(banner);
+  } finally {
+    win.dispose?.();
+    global.document = originalDocument;
+    global.window = originalWindow;
+  }
+});

--- a/core/tests/snort.test.mjs
+++ b/core/tests/snort.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildReqs, bucketReaction, dedupe, formatRelativeTime, normalizeRelayUrl } from '../static/js/snort.js';
+
+test('buildReqs constructs subscription frames', () => {
+  const reqs = buildReqs({ addr: '30023:pub:slug', eventId: 'evt', limit: 80 });
+  assert.equal(reqs.length, 2);
+  assert.ok(reqs[0].id);
+  assert.ok(reqs[1].id);
+  assert.deepEqual(reqs[0].frame, ['REQ', reqs[0].id, { kinds: [1, 7], '#a': ['30023:pub:slug'], limit: 80 }]);
+  assert.deepEqual(reqs[1].frame, ['REQ', reqs[1].id, { kinds: [1, 7], '#e': ['evt'], limit: 80 }]);
+
+  const older = buildReqs({ addr: '30023:pub:slug', limit: 10, until: 123 });
+  assert.equal(older.length, 1);
+  assert.deepEqual(older[0].frame, ['REQ', older[0].id, { kinds: [1, 7], '#a': ['30023:pub:slug'], limit: 10, until: 123 }]);
+});
+
+test('bucketReaction counts by emoji or content', () => {
+  const counts = new Map();
+  const first = bucketReaction({ tags: [['emoji', '❤️']], content: '' }, counts);
+  const second = bucketReaction({ tags: [], content: '+' }, counts);
+  assert.equal(first.key, '❤️');
+  assert.equal(first.total, 1);
+  assert.equal(second.key, '+');
+  assert.equal(second.total, 1);
+  assert.equal(counts.get('❤️'), 1);
+  assert.equal(counts.get('+'), 1);
+});
+
+test('bucketReaction updates plain objects when provided', () => {
+  const counts = {};
+  const result = bucketReaction({ content: '🔥' }, counts);
+  assert.equal(result.key, '🔥');
+  assert.equal(result.total, 1);
+  assert.equal(result.map.get('🔥'), 1);
+  assert.equal(counts['🔥'], 1);
+});
+
+test('dedupe tracks seen ids', () => {
+  const seen = new Set();
+  assert.equal(dedupe('a', seen), true);
+  assert.equal(dedupe('a', seen), false);
+  assert.equal(dedupe('', seen), false);
+});
+
+test('formatRelativeTime expresses human readable deltas', () => {
+  const now = Date.now();
+  assert.equal(formatRelativeTime(now - 30_000, now), '30s ago');
+  assert.equal(formatRelativeTime(now - 3_600_000, now), '1h ago');
+  assert.equal(formatRelativeTime(now + 120_000, now), 'in 2m');
+});
+
+test('normalizeRelayUrl upgrades protocols and resolves relative paths', () => {
+  const win = {
+    location: {
+      href: 'https://snort.test/posts/example',
+      origin: 'https://snort.test',
+      protocol: 'https:',
+      host: 'snort.test',
+    },
+  };
+
+  assert.equal(normalizeRelayUrl('/nostr', win), 'wss://snort.test/nostr');
+  assert.equal(normalizeRelayUrl('http://relay.example/path', win), 'ws://relay.example/path');
+  assert.equal(normalizeRelayUrl('wss://relay.example/', win), 'wss://relay.example/');
+  assert.equal(normalizeRelayUrl('mailto:user@example.com', win), null);
+});


### PR DESCRIPTION
## Summary
- decorate rendered posts with interactivity data attributes, live reaction/reply placeholders, CSP updates, and the deferred snort.js module under INTERACT_* flags
- ship a lightweight browser module that normalizes relay URLs, streams replies/reactions with pagination and failover, and exposes a NIP-07 reply dialog with accessibility affordances
- document the configuration, HTML contract, kill switch, and proxy requirements while extending bats and node integration tests to cover render hooks, pagination, signer gating, and relay failures

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68c741280a848320a1f1726752a0e455